### PR TITLE
Update CI workflows, add full test coverage, bump dependencies.

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,11 +13,7 @@ jobs:
     name: Audit dependencies
     runs-on: ubuntu-latest
     steps:
-      - uses: hecrj/setup-rust-action@110f36749599534ca96628b82f52ae67e5d95a3c
-      - name: Install cargo-audit
-        run: cargo install cargo-audit
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
-      - name: Resolve dependencies
-        run: cargo update
-      - name: Audit vulnerabilities
-        run: cargo audit
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v2.0.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Generate lockfile
+        run: cargo generate-lockfile
       - uses: rustsec/audit-check@v2.0.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,7 @@ jobs:
     name: Check
     runs-on: ubuntu-latest
     steps:
-      - uses: hecrj/setup-rust-action@110f36749599534ca96628b82f52ae67e5d95a3c
-        with:
-          components: clippy
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
       - name: Check
         run: cargo check --all-targets --all-features

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -15,9 +15,9 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: hecrj/setup-rust-action@110f36749599534ca96628b82f52ae67e5d95a3c
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Check format
         run: cargo fmt --all -- --check --verbose

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,9 +15,9 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: hecrj/setup-rust-action@110f36749599534ca96628b82f52ae67e5d95a3c
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
       - name: Check lints
         run: cargo clippy --all-features --all-targets --no-deps -- -D warnings

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,24 +1,26 @@
 name: 🏭 Cargo Test
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+  release:
+    types: [created]
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        toolchain: [stable]
-    continue-on-error: true
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd
+        uses: actions/checkout@v4
 
       - name: Setup Rust
-        run: |
-          rustup toolchain add ${{ matrix.toolchain }}
-          rustup override set ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Run tests
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "axum-tower-sessions-csrf"
-version = "0.1.1"
+version = "0.1.3"
 edition = "2021"
 authors = ["Grant DeFayette"]
 license = "MIT OR LGPL-3.0-or-later"
@@ -11,16 +11,18 @@ categories = ["web-programming", "authentication"]
 readme = "README.md"
 
 [dependencies]
-axum = { version = "0.8.7", default-features = false }
-tower-sessions = "0.14.0"
-rand = "0.9.2"
+axum = { version = "0.8.9", default-features = false }
+tower-sessions = "0.15.0"
+rand = "0.10.1"
 hex = "0.4.3"
-tracing = { version = "0.1.43", optional = true }
+tracing = { version = "0.1.44", optional = true }
 
 [features]
 default = ["tracing"]
 tracing = ["dep:tracing"]
 
 [dev-dependencies]
-tokio = { version = "1.48", features = ["macros", "rt"] }
-tower-sessions-memory-store = "0.14.0"
+tokio = { version = "1.51.1", features = ["macros", "rt"] }
+tower-sessions-memory-store = "0.15.0"
+tower = { version = "0.5.3", features = ["util"] }
+http-body-util = "0.1.3"

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ CSRF protection for Axum using tower-sessions, implementing the **Synchronizer T
 
 ```toml
 [dependencies]
-axum-tower-sessions-csrf = "0.1"
-tower-sessions = "0.14"
+axum-tower-sessions-csrf = "0.1.3"
+tower-sessions = "0.15"
 ```
 
 ## Quick Start

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,12 +19,12 @@
 //!
 //! ## Features
 //!
-//! - 🔒 Cryptographically secure token generation
-//! - 📦 Session-based token storage (no cookies needed)
-//! - ⚡ Constant-time token validation (prevents timing attacks)
-//! - 🎯 Automatic validation on POST/PUT/DELETE/PATCH requests
-//! - 🔧 Simple integration with existing Axum applications
-//! - 🪶 Lightweight with minimal dependencies
+//! - Cryptographically secure token generation
+//! - Session-based token storage (no cookies needed)
+//! - Constant-time token validation (prevents timing attacks)
+//! - Automatic validation on POST/PUT/DELETE/PATCH requests
+//! - Simple integration with existing Axum applications
+//! - Lightweight with minimal dependencies
 //!
 //! ## Quick Start
 //!
@@ -34,12 +34,12 @@
 //! use tower_sessions::{MemoryStore, SessionManagerLayer};
 //! use axum_tower_sessions_csrf::CsrfMiddleware;
 //!
-//! #[tokio::main]
+//! #[tokio::main(flavor = "current_thread")]
 //! async fn main() {
 //!     let session_store = MemoryStore::default();
 //!     let session_layer = SessionManagerLayer::new(session_store);
 //!
-//!     let app = Router::new()
+//!     let app: Router = Router::new()
 //!         .route("/", get(|| async { "Hello!" }))
 //!         .layer(from_fn(CsrfMiddleware::middleware))
 //!         .layer(session_layer);

--- a/src/token.rs
+++ b/src/token.rs
@@ -14,7 +14,7 @@
 //! CSRF token generation and session management
 
 use crate::TOKEN_KEY;
-use rand::Rng;
+use rand::RngExt;
 use tower_sessions::Session;
 
 /// Generate a cryptographically secure CSRF token
@@ -52,8 +52,7 @@ pub fn generate_token() -> String {
 ///
 /// # Examples
 ///
-/// ```ignore
-/// use axum::extract::Extension;
+/// ```no_run
 /// use tower_sessions::Session;
 /// use axum_tower_sessions_csrf::get_or_create_token;
 ///

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -49,12 +49,13 @@ impl CsrfMiddleware {
     ///
     /// # Examples
     ///
-    /// ```ignore
-    /// use axum::Router;
-    /// use axum::middleware::from_fn;
+    /// ```no_run
+    /// use axum::{Router, middleware::from_fn, routing::post};
     /// use axum_tower_sessions_csrf::CsrfMiddleware;
     ///
-    /// let app = Router::new()
+    /// async fn update_data() -> &'static str { "ok" }
+    ///
+    /// let app: Router = Router::new()
     ///     .route("/api/data", post(update_data))
     ///     .layer(from_fn(CsrfMiddleware::middleware));
     /// ```
@@ -151,5 +152,25 @@ mod tests {
         assert!(!CsrfMiddleware::constant_time_eq(b"test", b"test1"));
         assert!(!CsrfMiddleware::constant_time_eq(b"test1", b"test"));
         assert!(!CsrfMiddleware::constant_time_eq(b"", b"x"));
+    }
+
+    #[test]
+    fn test_validate_token_valid() {
+        let mut headers = HeaderMap::new();
+        headers.insert(TOKEN_HEADER, "abc123".parse().unwrap());
+        assert!(CsrfMiddleware::validate_token(&headers, "abc123"));
+    }
+
+    #[test]
+    fn test_validate_token_missing_header() {
+        let headers = HeaderMap::new();
+        assert!(!CsrfMiddleware::validate_token(&headers, "abc123"));
+    }
+
+    #[test]
+    fn test_validate_token_wrong_token() {
+        let mut headers = HeaderMap::new();
+        headers.insert(TOKEN_HEADER, "wrong_token".parse().unwrap());
+        assert!(!CsrfMiddleware::validate_token(&headers, "correct_token"));
     }
 }

--- a/tests/middleware_integration.rs
+++ b/tests/middleware_integration.rs
@@ -1,0 +1,288 @@
+use axum::{
+    body::Body,
+    http::{Method, Request, StatusCode},
+    middleware::from_fn,
+    routing::{delete, get, patch, post, put},
+    Router,
+};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+use tower_sessions::{MemoryStore, Session, SessionManagerLayer};
+
+use axum_tower_sessions_csrf::{get_or_create_token, CsrfMiddleware, TOKEN_HEADER};
+
+fn build_app() -> Router {
+    let session_store = MemoryStore::default();
+    let session_layer = SessionManagerLayer::new(session_store);
+
+    Router::new()
+        .route("/", get(|| async { "hello" }))
+        .route(
+            "/token",
+            get(|session: Session| async move { get_or_create_token(&session).await.unwrap() }),
+        )
+        .route("/post", post(|| async { "post ok" }))
+        .route("/put", put(|| async { "put ok" }))
+        .route("/delete", delete(|| async { "delete ok" }))
+        .route("/patch", patch(|| async { "patch ok" }))
+        .layer(from_fn(CsrfMiddleware::middleware))
+        .layer(session_layer)
+}
+
+fn extract_session_cookie(response: &axum::http::Response<Body>) -> Option<String> {
+    response
+        .headers()
+        .get_all("set-cookie")
+        .iter()
+        .find_map(|val| {
+            let s = val.to_str().ok()?;
+            Some(s.split(';').next()?.to_string())
+        })
+}
+
+async fn get_token_and_cookie(app: &Router) -> (String, String) {
+    let req = Request::builder()
+        .uri("/token")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let cookie = extract_session_cookie(&response).expect("should have session cookie");
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let token = String::from_utf8(body.to_vec()).unwrap();
+
+    (token, cookie)
+}
+
+// --- Safe methods pass through without token ---
+
+#[tokio::test]
+async fn test_get_passes_without_token() {
+    let app = build_app();
+    let req = Request::builder().uri("/").body(Body::empty()).unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"hello");
+}
+
+#[tokio::test]
+async fn test_head_passes_without_token() {
+    let app = build_app();
+    let req = Request::builder()
+        .method(Method::HEAD)
+        .uri("/")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    // HEAD on a GET route should not return 403
+    assert_ne!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_options_passes_without_token() {
+    let app = build_app();
+    let req = Request::builder()
+        .method(Method::OPTIONS)
+        .uri("/")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_ne!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// --- State-changing methods rejected without token ---
+
+#[tokio::test]
+async fn test_post_without_token_returns_403() {
+    let app = build_app();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/post")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_put_without_token_returns_403() {
+    let app = build_app();
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri("/put")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_delete_without_token_returns_403() {
+    let app = build_app();
+    let req = Request::builder()
+        .method(Method::DELETE)
+        .uri("/delete")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+#[tokio::test]
+async fn test_patch_without_token_returns_403() {
+    let app = build_app();
+    let req = Request::builder()
+        .method(Method::PATCH)
+        .uri("/patch")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// --- State-changing methods pass with valid token ---
+
+#[tokio::test]
+async fn test_post_with_valid_token_passes() {
+    let app = build_app();
+    let (token, cookie) = get_token_and_cookie(&app).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/post")
+        .header("cookie", &cookie)
+        .header(TOKEN_HEADER, &token)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"post ok");
+}
+
+#[tokio::test]
+async fn test_put_with_valid_token_passes() {
+    let app = build_app();
+    let (token, cookie) = get_token_and_cookie(&app).await;
+
+    let req = Request::builder()
+        .method(Method::PUT)
+        .uri("/put")
+        .header("cookie", &cookie)
+        .header(TOKEN_HEADER, &token)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"put ok");
+}
+
+#[tokio::test]
+async fn test_delete_with_valid_token_passes() {
+    let app = build_app();
+    let (token, cookie) = get_token_and_cookie(&app).await;
+
+    let req = Request::builder()
+        .method(Method::DELETE)
+        .uri("/delete")
+        .header("cookie", &cookie)
+        .header(TOKEN_HEADER, &token)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"delete ok");
+}
+
+#[tokio::test]
+async fn test_patch_with_valid_token_passes() {
+    let app = build_app();
+    let (token, cookie) = get_token_and_cookie(&app).await;
+
+    let req = Request::builder()
+        .method(Method::PATCH)
+        .uri("/patch")
+        .header("cookie", &cookie)
+        .header(TOKEN_HEADER, &token)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    assert_eq!(&body[..], b"patch ok");
+}
+
+// --- State-changing methods rejected with wrong token ---
+
+#[tokio::test]
+async fn test_post_with_wrong_token_returns_403() {
+    let app = build_app();
+    let (_token, cookie) = get_token_and_cookie(&app).await;
+
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/post")
+        .header("cookie", &cookie)
+        .header(TOKEN_HEADER, "totally_wrong_token")
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::FORBIDDEN);
+}
+
+// --- Token session behavior ---
+
+#[tokio::test]
+async fn test_token_created_on_first_request() {
+    let app = build_app();
+    let (token, _cookie) = get_token_and_cookie(&app).await;
+
+    assert_eq!(token.len(), 64, "Token should be 64 hex characters");
+    assert!(
+        token.chars().all(|c| c.is_ascii_hexdigit()),
+        "Token should only contain hex characters"
+    );
+}
+
+#[tokio::test]
+async fn test_token_is_idempotent() {
+    let app = build_app();
+    let (token1, cookie) = get_token_and_cookie(&app).await;
+
+    // Second request with same session cookie should return same token
+    let req = Request::builder()
+        .uri("/token")
+        .header("cookie", &cookie)
+        .body(Body::empty())
+        .unwrap();
+
+    let response = app.clone().oneshot(req).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body = response.into_body().collect().await.unwrap().to_bytes();
+    let token2 = String::from_utf8(body.to_vec()).unwrap();
+
+    assert_eq!(token1, token2, "Same session should return same token");
+}


### PR DESCRIPTION
This pull request introduces several improvements and updates across the codebase, including dependency updates, CI workflow modernization, and integration tests for CSRF middleware.

**Dependency and Version Updates:**

- Bumped the crate version to `0.1.3` and updated core dependencies to their latest versions, including `axum`, `tower-sessions`, `rand`, `tokio`, and others in `Cargo.toml`. Also updated the example and documentation to reflect the new versions. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L14-R28) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R27)

**Continuous Integration Workflow Modernization:**

- Updated all GitHub Actions workflows to use modern, maintained actions:
  - Replaced `hecrj/setup-rust-action` and hardcoded commit SHAs with `dtolnay/rust-toolchain@stable` and `actions/checkout@v4`.
  - Switched the audit workflow to use `rustsec/audit-check@v2.0.0` for dependency vulnerability checks.
  - Refined triggers for the test workflow to run on `push`, `pull_request`, and `release` events targeting `main`. [[1]](diffhunk://#diff-faff1af3d8ff408964a57b2e475f69a6b7c7b71c9978cccc8f471798caac2c88L3-R23) [[2]](diffhunk://#diff-93a89f16f6717d1e4e4e27ec20ef916e3355c7aa890ca74cd9b12db30d8a899fL16-R19) [[3]](diffhunk://#diff-55f05888fd854d9962bdd4d8ccf23a07b610990f58174397b2586b58f8937428L16-R17) [[4]](diffhunk://#diff-173f5db567f8459284c719180df8c27debad26456e63f98c5b87d94cf87e049bL18-L21) [[5]](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2L18-L21)

**Testing and Quality Improvements:**

- Added integration tests in `tests/middleware_integration.rs` to verify CSRF behavior, including token creation, validation, and enforcement across HTTP methods when used as an axum middleware.
- Expanded unit tests for token validation logic in `src/validation.rs`.

**Code Maintenance:**

- Updated imports and usage to match new dependency versions (e.g., `rand::RngExt` instead of `rand::Rng`).